### PR TITLE
Fix %patch macro for compatibility with RPM 4.20 and above

### DIFF
--- a/SPECS/slang.spec
+++ b/SPECS/slang.spec
@@ -7,7 +7,7 @@
 Summary:	Shared library for the S-Lang extension language
 Name:		slang
 Version:	2.3.2
-Release:	11%{?dist}
+Release:	11.1%{?dist}
 License:	GPLv2+
 URL:		https://www.jedsoft.org/slang/
 Source:		https://www.jedsoft.org/releases/%{name}/%{name}-%{version}.tar.bz2
@@ -55,8 +55,8 @@ based on the S-Lang extension language.
 
 %prep
 %setup -q
-%patch1 -p1 -b .getkey-memmove
-%patch2 -p1 -b .sighuptest
+%patch -P 1 -p1 -b .getkey-memmove
+%patch -P 2 -p1 -b .sighuptest
 
 # fix permissions of installed modules
 sed -i '/^INSTALL_MODULE=/s/_DATA//' configure
@@ -114,6 +114,9 @@ make check
 %{_includedir}/slang
 
 %changelog
+* Wed May 06 2026 Vincent Michel <vincent.michel@vates.tech> - 2.3.2-11.1
+- Fix the %%patch macro in the specfile to be compatible with rpm 4.20 and above
+
 * Tue Aug 10 2021 Mohan Boddu <mboddu@redhat.com> - 2.3.2-11
 - Rebuilt for IMA sigs, glibc 2.34, aarch64 flags
   Related: rhbz#1991688


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-2882

#### Related changes

Similar PRs in:
- [libreswan](https://github.com/xcp-ng-rpms/libreswan/pull/3)
- [fuse](https://github.com/xcp-ng-rpms/fuse/pull/1)
- [drbd](https://github.com/xcp-ng-rpms/drbd/pull/10)
- [netdata](https://github.com/xcp-ng-rpms/netdata/pull/9)
- [slang](https://github.com/xcp-ng-rpms/slang/pull/3)
- [systemtap](https://github.com/xcp-ng-rpms/systemtap/pull/3)

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Since [rpm 4.20.0]([https://rpm.org/releases/4.20.0](https://rpm.org/releases/4.20.0)
), the `%patchN` macro is no longer supported. This causes our `koji_build.py` script to fail if we happen to use rpm 4.20.0 or above (since the `specfile` python package is used to parse the RPM specfile). Here's the list of the affected repositories in [xcp-ng-rpms](https://github.com/xcp-ng-rpms):
- drbd
- fuse
- netdata
- slang
- systemtap

#### Release Target

- [x] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

The users are not affected by this change.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

No consequence on existing setups

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

<!-- Add links to the documentation update PRs if/when they are created. -->

N/A

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

I built a user package for `slang`, and installed it on a host along with `mc`. I then checked that `mc` runs properly:
```shell
$ yum install slang mc --enablerepo xcp-ng-vmichel1
$ yum provides /lib64/libslang.so.2
slang-2.3.2-11.1~xcpng2882.1.xcpng8.3.x86_64 : Shared library for the S-Lang extension language
Repo        : @xcp-ng-vmichel1
$ ldd /bin/mc
	[...]
	libslang.so.2 => /lib64/libslang.so.2 (0x00007fb3b982d000)
$ mc
```

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

Slang is mainly used by `host-installer`, but testing `host-installer` seems a bit complicated.
At least running the `mc` test above should provide a minimal basis.

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->
None, slang is used for the TUI part of `host-installer`.

#### What tests have been or will be added to CI for this change? If none, explain why.

None, the sources haven't been updated and testing a TUI is hard.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
